### PR TITLE
Closes Issue #4 - See Individual Reminder

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -8,7 +8,7 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
   this.route('reminders', function() {
-    this.route('reminder', {path: '/:post_id'});
+    this.route('reminder', {path: ':reminder_id'});
   });
 });
 

--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,9 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('reminders');
+  this.route('reminders', function() {
+    this.route('reminder', {path: '/:post_id'});
+  });
 });
 
 export default Router;

--- a/app/routes/reminders/reminder.js
+++ b/app/routes/reminders/reminder.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/app/routes/reminders/reminder.js
+++ b/app/routes/reminders/reminder.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  model(params) {
+    return this.get('store').find('reminder', params.reminder_id)
+  }
 });

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,0 +1,3 @@
+.active {
+  color: aqua;
+}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,5 +1,3 @@
-{{outlet}}
-
 <ul class="reminder-list">
   {{#each model as |reminder|}}
     <li class='spec-reminder-item'>
@@ -7,3 +5,5 @@
     </li>
   {{/each}}
 </ul>
+
+{{outlet}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,8 +1,10 @@
 <ul class="reminder-list">
   {{#each model as |reminder|}}
-    <li class='spec-reminder-item'>
-        {{reminder.title}}
-    </li>
+    {{#link-to 'reminders.reminder' reminder}}
+      <li class='spec-reminder-item'>
+          {{reminder.title}}
+      </li>
+    {{/link-to}}
   {{/each}}
 </ul>
 

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,0 +1,3 @@
+{{outlet}}
+
+<h4>{{Reminder}}</h4>

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,3 +1,5 @@
 {{outlet}}
 
-<h4>{{Reminder}}</h4>
+<h2>{{model.title}}</h2>
+<h5>{{model.date}}</h5>
+<p>{{model.notes}}</p>

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -29,14 +29,38 @@ test('viewing the homepage', function(assert) {
   });
 });
 
-skip('clicking on an individual item', function(assert) {
+test('clicking on an individual item', function(assert) {
   server.createList('reminder', 5);
 
   visit('/');
   click('.spec-reminder-item:first');
 
   andThen(function() {
-    assert.equal(currentURL(), '/1');
-    assert.equal(Ember.$('.spec-reminder-item:first').text().trim(), Ember.$('.spec-reminder-title').text().trim());
+    assert.equal(currentURL(), '/reminders/1');
+    assert.equal(Ember.$('.spec-reminder-item:first').length, 1);
+  });
+});
+
+test('clicking on an individual item shows one reminder', function(assert) {
+  server.createList('reminder', 5);
+
+  visit('/');
+  click('.spec-reminder-item:first');
+
+  andThen(function() {
+    assert.equal(find('h2').length, 1);
+    assert.equal(find('h5').length, 1);
+    assert.equal(find('p').length, 1);
+  });
+});
+
+test('clicking on an individual item adds an active class to that link', function(assert) {
+  server.createList('reminder', 5);
+
+  visit('/');
+  click('.spec-reminder-item:first');
+
+  andThen(function() {
+    assert.equal(find('.active').length, 1);
   });
 });

--- a/tests/unit/routes/reminders/reminder-test.js
+++ b/tests/unit/routes/reminders/reminder-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:reminders/reminder', 'Unit | Route | reminders/reminder', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
## Purpose

When the user clicks on one of the reminders on the page, they are taken to an individual reminders route (ie: '/reminders/1', if the id of the reminder is 1). The title of the reminder object should be displayed.

## Approach

We nested a route to the individual reminders in the router, using the reminder id, and added a 'Link to' around each Reminder item in the displayed list, that when clicked on displayed the reminder template with that individual reminder/reminder details.

### Learning

[Defining your routes](https://guides.emberjs.com/v2.9.0/routing/defining-your-routes/)
[Specifying a Route's Model](https://guides.emberjs.com/v2.9.0/routing/specifying-a-routes-model/)

#### Blog Posts
N/A

### Open Questions and Pre-Merge TODOs

- [x]  render reminder items to page
- [x] reroute to /reminders when directing towards root index
- [x] updated test to account for redirection
- [x] get all tests passing by adding links for each reminder
- [x] added route to individual reminder
- [x] wrote acceptance tests to test the individual reminders/making sure clicking on one of the list items would render the reminder information on the DOM
- [x] added active class styles to the a tags (reminders)
- [ ] create a new reminder

### Test coverage 

We wrote several acceptance tests to cover the reminder list and individual reminders
* Tested that the page would reroute to the id of the individual reminder (i.e 'reminders/1')
* Tested that an active class was added to the active reminders link
* Tested that a single reminder was rendered to the DOM when a user clicked on a reminder in the reminder list

### Merge Dependencies and Related Work

issue #3 

### Follow-up tasks

issue #6 

### Screenshots

#### Before

![hq81mi7vih](https://cloud.githubusercontent.com/assets/16638363/20989567/531243f2-bc92-11e6-9862-bcd8e8b28078.gif)


#### After

![ajnudbwcbi](https://cloud.githubusercontent.com/assets/16638363/20989491/0976a62a-bc92-11e6-9d16-711a1a343731.gif)
